### PR TITLE
Fix footnote URL overflow on mobile

### DIFF
--- a/blog-src/_includes/layout.njk
+++ b/blog-src/_includes/layout.njk
@@ -401,6 +401,19 @@
     .blog-content thead th { background: var(--tag-bg); }
     .blog-content img { display: block; max-width: 100%; height: auto; border-radius: 10px; margin: 1.5rem auto; }
 
+    /* Footnotes */
+    .blog-content .footnotes {
+      margin-top: 2.5rem;
+      font-size: 0.85rem;
+      color: var(--muted);
+    }
+    .blog-content .footnotes-sep { margin-top: 2rem; }
+    .blog-content .footnotes-list { padding-left: 1.5rem; margin: 0.5rem 0 0; }
+    .blog-content .footnote-item { margin: 0.35rem 0; overflow-wrap: anywhere; }
+    .blog-content .footnote-item p { margin: 0; }
+    .blog-content .footnote-item a { overflow-wrap: anywhere; }
+    .blog-content .footnote-backref { overflow-wrap: normal; word-break: normal; margin-left: 0.2rem; }
+
 
      /* Back to portfolio button */
      .back-to-portfolio {


### PR DESCRIPTION
## Summary

- Add CSS for the footnotes section so long URLs wrap instead of causing horizontal scroll on mobile
- `↩︎` backref now stays inline at the end of the URL rather than wrapping to its own line

## Test plan

- [ ] View the capitalism post on a mobile-sized viewport and confirm footnote URLs wrap cleanly with no horizontal overflow
- [ ] Confirm the `↩︎` backref appears at the end of each footnote, not on a new line

https://claude.ai/code/session_01CPEgNxR9ZH6dKmQJMUU3UV

---
_Generated by [Claude Code](https://claude.ai/code/session_01CPEgNxR9ZH6dKmQJMUU3UV)_