### PR TITLE
Add shimmer skeleton for post thumbnail images

### DIFF
--- a/blog-src/_includes/layout.njk
+++ b/blog-src/_includes/layout.njk
@@ -282,11 +282,36 @@
     }
     .post-item + .post-item { border-top: 1px solid var(--border); }
     
-    .post-item-image img{
+    .post-item-image {
+      flex: none;
+      width: 180px;
+      height: 180px;
+      border-radius: 10px;
+      overflow: hidden;
+      position: relative;
+      background: var(--tag-bg);
+    }
+
+    @keyframes shimmer {
+      from { background-position: -180px 0; }
+      to { background-position: 180px 0; }
+    }
+
+    .post-item-image::before {
+      content: '';
+      position: absolute;
+      inset: 0;
+      background: linear-gradient(90deg, transparent 0%, var(--border) 50%, transparent 100%);
+      background-size: 360px 100%;
+      animation: shimmer 1.5s ease-in-out infinite;
+    }
+
+    .post-item-image img {
       max-height: 180px;
       height: 180px;
       width: 180px;
-      max-width: auto;
+      max-width: none;
+      position: relative;
     }
 
     

--- a/blog-src/index.njk
+++ b/blog-src/index.njk
@@ -18,7 +18,7 @@ permalink: "{% if pagination.pageNumber == 0 %}/blog/{% else %}/blog/page/{{ pag
         <div class="post-item-image">
             <div class="post-preview-image">
               <a href="{{ post.url }}">
-                <img src="{{ post.data.image }}" alt="{{ post.data.title }}" />
+                <img src="{{ post.data.image }}" alt="{{ post.data.title }}" loading="lazy" width="180" height="180" />
               </a>
             </div>
         </div>


### PR DESCRIPTION
## Summary

- Reserve fixed 180×180 space for thumbnail images so the layout never shifts while images load
- Add an animated shimmer placeholder that plays until the image is ready
- Add `loading="lazy"` and explicit `width`/`height` attributes to help the browser avoid reflow

## Test plan

- [ ] Visit the blog index on a slow connection and confirm thumbnails show the shimmer placeholder before loading
- [ ] Confirm no layout jitter as images load in
- [ ] Verify layout looks correct on both desktop and mobile

https://claude.ai/code/session_01CPEgNxR9ZH6dKmQJMUU3UV

---
_Generated by [Claude Code](https://claude.ai/code/session_01CPEgNxR9ZH6dKmQJMUU3UV)_