### PR TITLE
Fix thumbnail image offset caused by inline baseline gap

### DIFF
--- a/blog-src/_includes/layout.njk
+++ b/blog-src/_includes/layout.njk
@@ -307,6 +307,7 @@
     }
 
     .post-item-image img {
+      display: block;
       max-height: 180px;
       height: 180px;
       width: 180px;
@@ -374,6 +375,8 @@
     .image-caption { font-size: 0.9rem; color: var(--muted); font-style: italic; margin: 0.5rem 0 0 0; }
 
     .post-preview-image { margin: 0; }
+    .post-preview-image,
+    .post-preview-image a { display: block; height: 100%; }
     .post-preview-image img {
       width: 100%;
       height: 180px;


### PR DESCRIPTION
## Summary

- Fix thumbnail images being pushed down ~20px and cropped at the bottom
- Root cause: the `<a>` wrapping each image was an inline element, causing the browser to reserve descender space and shift the image down inside the clipped container
- Fix: set `display: block; height: 100%` on `.post-preview-image` and its `<a>`, and `display: block` on the `<img>`

## Test plan

- [ ] Visit the blog index and confirm thumbnail images are no longer offset — no white strip at the top, no cropping at the bottom

https://claude.ai/code/session_01CPEgNxR9ZH6dKmQJMUU3UV

---
_Generated by [Claude Code](https://claude.ai/code/session_01CPEgNxR9ZH6dKmQJMUU3UV)_