### PR TITLE
Fix thumbnail image offset caused by .blog-content img specificity leak

### DIFF
--- a/blog-src/_includes/layout.njk
+++ b/blog-src/_includes/layout.njk
@@ -298,10 +298,12 @@
       animation: shimmer 1.5s ease-in-out infinite;
     }
 
-    .post-item-image img {
+    .post-item .post-item-image img {
       display: block;
       height: 180px;
       width: 180px;
+      margin: 0;
+      border-radius: 0;
     }
 
     


### PR DESCRIPTION
## Summary

- Fix thumbnail images being pushed down by `margin: 1.5rem auto` and `height: auto` leaking from the `.blog-content img` rule
- Root cause: `.blog-content img` appears later in the stylesheet at the same specificity, silently overriding the thumbnail height and adding ~24px top margin (the visible gray strip)
- Fix: use `.post-item .post-item-image img` (higher specificity) to reset `margin: 0`, `height: 180px`, and `border-radius: 0`

## Test plan

- [ ] Visit the blog index and confirm thumbnail images sit flush at the top of their containers with no gray strip
- [ ] Confirm post body images are unaffected and still have their `1.5rem` margin

https://claude.ai/code/session_01CPEgNxR9ZH6dKmQJMUU3UV

---
_Generated by [Claude Code](https://claude.ai/code/session_01CPEgNxR9ZH6dKmQJMUU3UV)_